### PR TITLE
fix(readme): typo in predict example

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,5 +90,5 @@ number of epochs of 1000 for example, the net will process each entry in the dat
 ### Predict an output
 
 ```javascript
-myNet.predict([[0,1]]);  // hopefully outputs 1 ;)
+myNet.predict([0,1]);  // hopefully outputs 1 ;)
 ```


### PR DESCRIPTION
This PR fixes a typo in the predict function example in the readme.